### PR TITLE
Using BPDisplaySettings again, re-add wrapper object BPAttributedStringConverted to keep public API intact

### DIFF
--- a/Bypass.xcodeproj/project.pbxproj
+++ b/Bypass.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		5ED7EAC517A3253B00CC7087 /* BPParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5ED7EAC317A3253B00CC7087 /* BPParser.mm */; };
 		5ED7EACA17A3257200CC7087 /* BPAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED7EAC717A3257200CC7087 /* BPAccessibilityElement.m */; };
 		5ED7EACB17A3257200CC7087 /* BPAccessibilityVisitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED7EAC917A3257200CC7087 /* BPAccessibilityVisitor.m */; };
+		9BF7A72D17AA694500819735 /* BPAttributedStringConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BF7A72C17AA694300819735 /* BPAttributedStringConverter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +116,9 @@
 		5ED7EAC717A3257200CC7087 /* BPAccessibilityElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPAccessibilityElement.m; sourceTree = "<group>"; };
 		5ED7EAC817A3257200CC7087 /* BPAccessibilityVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPAccessibilityVisitor.h; sourceTree = "<group>"; };
 		5ED7EAC917A3257200CC7087 /* BPAccessibilityVisitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPAccessibilityVisitor.m; sourceTree = "<group>"; };
+		9BF7A72A17AA654700819735 /* Bypass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Bypass.h; sourceTree = "<group>"; };
+		9BF7A72B17AA694100819735 /* BPAttributedStringConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPAttributedStringConverter.h; sourceTree = "<group>"; };
+		9BF7A72C17AA694300819735 /* BPAttributedStringConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPAttributedStringConverter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -212,6 +216,7 @@
 		5ED7EA4517A31FBE00CC7087 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				9BF7A72A17AA654700819735 /* Bypass.h */,
 				5ED7EA4617A31FBE00CC7087 /* Bypass-Prefix.pch */,
 			);
 			name = "Supporting Files";
@@ -250,8 +255,8 @@
 		5ED7EA6C17A3205200CC7087 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				5ED7EAC217A3253B00CC7087 /* BPParser.h */,
-				5ED7EAC317A3253B00CC7087 /* BPParser.mm */,
+				9BF7A72B17AA694100819735 /* BPAttributedStringConverter.h */,
+				9BF7A72C17AA694300819735 /* BPAttributedStringConverter.m */,
 				5ED7EAA217A3241800CC7087 /* BPAttributedTextVisitor.h */,
 				5ED7EAA317A3241800CC7087 /* BPAttributedTextVisitor.m */,
 				5ED7EAA417A3241800CC7087 /* BPDisplaySettings.h */,
@@ -264,6 +269,8 @@
 				5ED7EAAB17A3241800CC7087 /* BPElementPrivate.h */,
 				5ED7EAAC17A3241800CC7087 /* BPElementWalker.h */,
 				5ED7EAAD17A3241800CC7087 /* BPElementWalker.m */,
+				5ED7EAC217A3253B00CC7087 /* BPParser.h */,
+				5ED7EAC317A3253B00CC7087 /* BPParser.mm */,
 				5ED7EAAE17A3241800CC7087 /* BPTextVisitor.h */,
 				5ED7EAAF17A3241800CC7087 /* BPTextVisitor.m */,
 			);
@@ -404,6 +411,7 @@
 				5E95248617A854CC00B174C2 /* array.c in Sources */,
 				5E95248817A854CC00B174C2 /* buffer.c in Sources */,
 				5E95248A17A854CC00B174C2 /* markdown.c in Sources */,
+				9BF7A72D17AA694500819735 /* BPAttributedStringConverter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bypass/BPAttributedStringConverter.h
+++ b/Bypass/BPAttributedStringConverter.h
@@ -1,0 +1,25 @@
+//
+//  BPAttributedStringConverter.h
+//  Bypass
+//
+//  Created by Matthias Tretter on 01.08.13.
+//  Copyright (c) 2013 Uncodin, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+@class BPDisplaySettings;
+@class BPDocument;
+
+
+/*!
+ \brief Renders a Bypass Document to an `NSAttributedString`.
+ */
+@interface BPAttributedStringConverter : NSObject
+
+@property(nonatomic, strong) BPDisplaySettings *displaySettings;
+
+- (NSAttributedString *)convertDocument:(BPDocument *)document;
+
+@end

--- a/Bypass/BPAttributedStringConverter.m
+++ b/Bypass/BPAttributedStringConverter.m
@@ -1,0 +1,29 @@
+//
+//  BPAttributedStringConverter.m
+//  Bypass
+//
+//  Created by Matthias Tretter on 01.08.13.
+//  Copyright (c) 2013 Uncodin, Inc. All rights reserved.
+//
+
+#import "BPAttributedStringConverter.h"
+#import "BPAttributedTextVisitor.h"
+#import "BPDisplaySettings.h"
+#import "BPDocument.h"
+#import "BPElementWalker.h"
+
+
+@implementation BPAttributedStringConverter
+
+- (NSAttributedString *)convertDocument:(BPDocument *)document {
+    BPAttributedTextVisitor *visitor = [BPAttributedTextVisitor new];
+    BPElementWalker *walker = [BPElementWalker new];
+
+    [walker addElementVisitor:visitor];
+    [walker walkDocument:document];
+
+    NSAttributedString *attributedString = visitor.attributedText;
+    return attributedString;
+}
+
+@end

--- a/Bypass/BPAttributedStringConverter.m
+++ b/Bypass/BPAttributedStringConverter.m
@@ -20,11 +20,15 @@
     BPAttributedTextVisitor *visitor = [BPAttributedTextVisitor new];
     BPElementWalker *walker = [BPElementWalker new];
 
+    [visitor setDisplaySettings:self.displaySettings];
     [walker addElementVisitor:visitor];
     [walker walkDocument:document];
 
-    NSAttributedString *attributedString = visitor.attributedText;
+    NSMutableAttributedString *attributedString = visitor.attributedText;
+    [attributedString addAttribute:NSForegroundColorAttributeName value:[_displaySettings defaultColor] range:NSMakeRange(0, attributedString.length)];
+
     return attributedString;
 }
+
 
 @end

--- a/Bypass/BPAttributedStringConverter.m
+++ b/Bypass/BPAttributedStringConverter.m
@@ -15,7 +15,8 @@
 
 @implementation BPAttributedStringConverter
 
-- (NSAttributedString *)convertDocument:(BPDocument *)document {
+- (NSAttributedString *)convertDocument:(BPDocument *)document
+{
     BPAttributedTextVisitor *visitor = [BPAttributedTextVisitor new];
     BPElementWalker *walker = [BPElementWalker new];
 

--- a/Bypass/BPAttributedStringConverter.m
+++ b/Bypass/BPAttributedStringConverter.m
@@ -13,22 +13,45 @@
 #import "BPElementWalker.h"
 
 
+@interface BPAttributedStringConverter ()
+
+@property (nonatomic, strong) BPAttributedTextVisitor *visitor;
+@property (nonatomic, strong) BPElementWalker *walker;
+
+@end
+
 @implementation BPAttributedStringConverter
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        _visitor = [BPAttributedTextVisitor new];
+        _walker = [BPElementWalker new];
+        [_walker addElementVisitor:_visitor];
+    }
+    return self;
+}
 
 - (NSAttributedString *)convertDocument:(BPDocument *)document
 {
-    BPAttributedTextVisitor *visitor = [BPAttributedTextVisitor new];
-    BPElementWalker *walker = [BPElementWalker new];
+    [_visitor resetAttributedText];
+    [_walker walkDocument:document];
 
-    [visitor setDisplaySettings:self.displaySettings];
-    [walker addElementVisitor:visitor];
-    [walker walkDocument:document];
-
-    NSMutableAttributedString *attributedString = visitor.attributedText;
-    [attributedString addAttribute:NSForegroundColorAttributeName value:[_displaySettings defaultColor] range:NSMakeRange(0, attributedString.length)];
+    NSMutableAttributedString *attributedString = _visitor.attributedText;
+    [attributedString addAttribute:NSForegroundColorAttributeName
+                             value:[_visitor.displaySettings defaultColor]
+                             range:NSMakeRange(0, attributedString.length)];
 
     return attributedString;
 }
 
+- (void)setDisplaySettings:(BPDisplaySettings *)displaySettings {
+    _visitor.displaySettings = displaySettings;
+}
+
+- (BPDisplaySettings *)displaySettings {
+    return _visitor.displaySettings;
+}
 
 @end

--- a/Bypass/BPAttributedTextVisitor.h
+++ b/Bypass/BPAttributedTextVisitor.h
@@ -23,11 +23,14 @@
 #import <UIKit/UIKit.h>
 #import "BPElementWalker.h"
 
+@class BPDisplaySettings;
+
 OBJC_EXPORT NSString* const BPLinkStyleAttributeName;
 
 @interface BPAttributedTextVisitor : NSObject <BPElementVisitor>
 
 @property (nonatomic, readonly) NSMutableAttributedString* attributedText;
+@property (nonatomic, strong) BPDisplaySettings *displaySettings;
 
 - (void)resetAttributedText;
 

--- a/Bypass/BPAttributedTextVisitor.h
+++ b/Bypass/BPAttributedTextVisitor.h
@@ -27,6 +27,8 @@ OBJC_EXPORT NSString* const BPLinkStyleAttributeName;
 
 @interface BPAttributedTextVisitor : NSObject <BPElementVisitor>
 
-@property NSMutableAttributedString*  attributedText;
+@property (nonatomic, readonly) NSMutableAttributedString* attributedText;
+
+- (void)resetAttributedText;
 
 @end

--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -88,6 +88,11 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
     if (_h6Font != NULL)         CFRelease(_h6Font);
 }
 
+- (void)resetAttributedText
+{
+    _attributedText = [[NSMutableAttributedString alloc] init];
+}
+
 #pragma mark Fonts
 
 - (UIFont *)UIFontFromCTFont:(CTFontRef)ctFont

--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -20,31 +20,13 @@
 
 #import "BPAttributedTextVisitor.h"
 #import "BPElement.h"
+#import "BPDisplaySettings.h"
 
 NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
 
-static const CGFloat kBulletIndentation     = 13.0f;
-static const CGFloat kCodeIndentation       = 10.0f;
-static const CGFloat kQuoteIndentation      = 23.0f;
-static const CGFloat kLineSpacingSmall      =  1.2f;
-static const CGFloat kParagraphSpacingLarge = 20.0f;
-static const CGFloat kParagraphSpacingSmall = 10.0f;
-static const CGFloat kParagraphSpacingNone  =  0.0f;
 
-@implementation BPAttributedTextVisitor
-{
-    CTFontRef _defaultFont;
-    CTFontRef _boldFont;
-    CTFontRef _italicFont;
-    CTFontRef _boldItalicFont;
-    CTFontRef _monospaceFont;
-    CTFontRef _quoteFont;
-    CTFontRef _h1Font;
-    CTFontRef _h2Font;
-    CTFontRef _h3Font;
-    CTFontRef _h4Font;
-    CTFontRef _h5Font;
-    CTFontRef _h6Font;
+@implementation BPAttributedTextVisitor {
+    BOOL _renderedFirstParagraph;
 }
 
 - (id)init
@@ -53,25 +35,10 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
     
     if (self != nil) {
         _attributedText = [[NSMutableAttributedString alloc] init];
+        _displaySettings = [[BPDisplaySettings alloc] init];
     }
     
     return self;
-}
-
-- (void)dealloc
-{
-    if (_defaultFont != NULL)    CFRelease(_defaultFont);
-    if (_boldFont != NULL)       CFRelease(_boldFont);
-    if (_italicFont != NULL)     CFRelease(_italicFont);
-    if (_boldItalicFont != NULL) CFRelease(_boldItalicFont);
-    if (_monospaceFont != NULL)  CFRelease(_monospaceFont);
-    if (_quoteFont != NULL)      CFRelease(_quoteFont);
-    if (_h1Font != NULL)         CFRelease(_h1Font);
-    if (_h2Font != NULL)         CFRelease(_h2Font);
-    if (_h3Font != NULL)         CFRelease(_h3Font);
-    if (_h4Font != NULL)         CFRelease(_h4Font);
-    if (_h5Font != NULL)         CFRelease(_h5Font);
-    if (_h6Font != NULL)         CFRelease(_h6Font);
 }
 
 - (void)resetAttributedText
@@ -93,152 +60,6 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
        withTextRange:(NSRange)textRange
 {
     return [self convertElement:element toTarget:_attributedText range:textRange];
-}
-
-#pragma mark Fonts
-
-- (UIFont *)UIFontFromCTFont:(CTFontRef)ctFont
-{
-    NSString *fontName;
-    fontName = (__bridge_transfer NSString *) CTFontCopyName(ctFont, kCTFontPostScriptNameKey);
-    
-    CGFloat fontSize = CTFontGetSize(ctFont);
-    UIFont *font = [UIFont fontWithName:fontName size:fontSize];
-    return font;
-}
-
-- (CTFontRef)defaultFont
-{
-    if (_defaultFont == NULL) {
-        CGFloat systemFontSize = [UIFont systemFontSize];
-        UIFont *systemFont = [UIFont systemFontOfSize:systemFontSize];
-        CFStringRef systemFontName = (__bridge CFStringRef) [systemFont fontName];
-        
-        _defaultFont = CTFontCreateWithName(systemFontName, systemFontSize, NULL);
-    }
-    
-    return _defaultFont;
-}
-
-- (CTFontRef)boldFont
-{
-    if (_boldFont == NULL) {
-        _boldFont = CTFontCreateCopyWithSymbolicTraits([self defaultFont],
-                                                       0.f,
-                                                       NULL,
-                                                       kCTFontBoldTrait,
-                                                       kCTFontBoldTrait);
-    }
-    
-    return _boldFont;
-}
-
-- (CTFontRef)italicFont
-{
-    if (_italicFont == NULL) {
-        _italicFont = CTFontCreateCopyWithSymbolicTraits([self defaultFont],
-                                                         0.f,
-                                                         NULL,
-                                                         kCTFontItalicTrait,
-                                                         kCTFontItalicTrait);
-    }
-    
-    return _italicFont;
-}
-
-- (CTFontRef)boldItalicFont
-{
-    if (_boldItalicFont == NULL) {
-        CTFontSymbolicTraits traits = kCTFontBoldTrait | kCTFontItalicTrait;
-        CTFontSymbolicTraits mask = kCTFontBoldTrait | kCTFontItalicTrait;
-        _boldItalicFont = CTFontCreateCopyWithSymbolicTraits([self defaultFont],
-                                                             0.f,
-                                                             NULL,
-                                                             traits,
-                                                             mask);
-    }
-    
-    return _boldItalicFont;
-}
-
-- (CTFontRef)monospaceFont
-{
-    if (_monospaceFont == NULL) {
-        _monospaceFont = CTFontCreateWithName(CFSTR("Courier"),
-                                              CTFontGetSize([self defaultFont]) - 2, NULL);
-    }
-    
-    return _monospaceFont;
-}
-
-- (CTFontRef)quoteFont
-{
-    if (_quoteFont == NULL) {
-        _quoteFont = CTFontCreateWithName(CFSTR("Marion-Italic"),
-                                          CTFontGetSize([self defaultFont]) + 2, NULL);
-    }
-    
-    return _quoteFont;
-}
-
-- (CTFontRef)h1Font
-{
-    if (_h1Font == NULL) {
-        _h1Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 2, NULL);
-    }
-    
-    return _h1Font;
-}
-
-- (CTFontRef)h2Font
-{
-    if (_h2Font == NULL) {
-        _h2Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.8, NULL);
-    }
-    
-    return _h2Font;
-}
-
-- (CTFontRef)h3Font
-{
-    if (_h3Font == NULL) {
-        _h3Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.6, NULL);
-    }
-    
-    return _h3Font;
-}
-
-- (CTFontRef)h4Font
-{
-    if (_h4Font == NULL) {
-        _h4Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.4, NULL);
-    }
-    
-    return _h4Font;
-}
-
-- (CTFontRef)h5Font
-{
-    if (_h5Font == NULL) {
-        _h5Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.2, NULL);
-    }
-    
-    return _h5Font;
-}
-
-- (CTFontRef)h6Font
-{
-    if (_h6Font == NULL) {
-        _h6Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1, NULL);
-    }
-    
-    return _h6Font;
 }
 
 #pragma mark Rendering
@@ -319,7 +140,7 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
                       atIndex:(int)index
 {
     NSDictionary *bulletAttributes = @{
-                                       NSFontAttributeName            : [self UIFontFromCTFont:[self monospaceFont]],
+                                       NSFontAttributeName            : [_displaySettings monospaceFont],
                                        NSForegroundColorAttributeName : bulletColor
                                        };
     
@@ -335,7 +156,7 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 #pragma mark Span Element Rendering
 
 - (void)renderSpanElement:(BPElement *)element
-                 withFont:(CTFontRef)font
+                 withFont:(UIFont *)font
                  toTarget:(NSMutableAttributedString *)target
 {
     [self renderSpanElement:element
@@ -345,11 +166,11 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 }
 
 - (void)renderSpanElement:(BPElement *)element
-                 withFont:(CTFontRef)font
+                 withFont:(UIFont *)font
                attributes:(NSMutableDictionary *)attributes
                  toTarget:(NSMutableAttributedString *)target
 {
-    attributes[NSFontAttributeName] = [self UIFontFromCTFont:font];
+    attributes[NSFontAttributeName] = font;
     
     NSString *text;
     
@@ -361,39 +182,52 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
     } else {
         text = [[element text] stringByReplacingOccurrencesOfString:@"\n" withString:@" "];
     }
-    
-    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text
-                                                                         attributes:attributes];
-    [target appendAttributedString:attributedText];
+
+    if (text != nil) {
+        NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text
+                                                                             attributes:attributes];
+        [target appendAttributedString:attributedText];
+    }
 }
 
 - (void)renderTextElement:(BPElement *)element toTarget:(NSMutableAttributedString *)target
 {
-    [self renderSpanElement:element withFont:[self defaultFont] toTarget:target];
+    [self renderSpanElement:element withFont:[_displaySettings defaultFont] toTarget:target];
 }
 
 - (void)renderBoldItalicElement:(BPElement *)element
                        toTarget:(NSMutableAttributedString *)target
 {
-    [self renderSpanElement:element withFont:[self boldItalicFont] toTarget:target];
+    [self renderSpanElement:element withFont:[_displaySettings boldItalicFont] toTarget:target];
 }
 
 - (void)renderBoldElement:(BPElement *)element
                  toTarget:(NSMutableAttributedString *)target
 {
-    [self renderSpanElement:element withFont:[self boldFont] toTarget:target];
+    [self renderSpanElement:element withFont:[_displaySettings boldFont] toTarget:target];
 }
 
 - (void)renderItalicElement:(BPElement *)element
                    toTarget:(NSMutableAttributedString *)target
 {
-    [self renderSpanElement:element withFont:[self italicFont] toTarget:target];
+    [self renderSpanElement:element withFont:[_displaySettings italicFont] toTarget:target];
+}
+
+- (void)renderStruckthroughElement:(BPElement *)element
+                          toTarget:(NSMutableAttributedString *)target
+{
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+    attributes[NSStrikethroughStyleAttributeName] = @(1);
+    [self renderSpanElement:element
+                   withFont:[_displaySettings defaultFont]
+                 attributes:attributes
+                   toTarget:target];
 }
 
 - (void)renderCodeSpanElement:(BPElement *)element
                      toTarget:(NSMutableAttributedString *)target
 {
-    [self renderSpanElement:element withFont:[self monospaceFont] toTarget:target];
+    [self renderSpanElement:element withFont:[_displaySettings monospaceFont] toTarget:target];
 }
 
 - (void)renderLinkElement:(BPElement *)element
@@ -401,10 +235,10 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
     attributes[NSUnderlineStyleAttributeName] = @(NSUnderlineStyleSingle);
-    attributes[NSForegroundColorAttributeName] = [UIColor blueColor];
+    attributes[NSForegroundColorAttributeName] = [_displaySettings linkColor];
     attributes[BPLinkStyleAttributeName] = element[@"link"];
     [self renderSpanElement:element
-                   withFont:_defaultFont
+                   withFont:[_displaySettings defaultFont]
                  attributes:attributes toTarget:target];
 }
 
@@ -421,13 +255,14 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
                        toTarget:(NSMutableAttributedString *)target
 {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
-    attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self quoteFont]];
+    attributes[NSFontAttributeName] = [_displaySettings quoteFont];
+    attributes[NSForegroundColorAttributeName] = [_displaySettings quoteColor];
     
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    [paragraphStyle setParagraphSpacing:kParagraphSpacingSmall];
-    [paragraphStyle setFirstLineHeadIndent:kQuoteIndentation];
-    [paragraphStyle setHeadIndent:kQuoteIndentation];
-    [paragraphStyle setTailIndent:-kQuoteIndentation];
+    [paragraphStyle setParagraphSpacing:[_displaySettings paragraphSpacingHeading]];
+    [paragraphStyle setFirstLineHeadIndent:[_displaySettings quoteIndentation]];
+    [paragraphStyle setHeadIndent:[_displaySettings quoteIndentation]];
+    [paragraphStyle setTailIndent:-[_displaySettings quoteIndentation]];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     [target addAttributes:attributes range:effectiveRange];
@@ -440,14 +275,14 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
     int insertedCharacters = 0;
     
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
-    attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self monospaceFont]];
-    attributes[NSForegroundColorAttributeName] = [UIColor grayColor];
+    attributes[NSFontAttributeName] = [_displaySettings monospaceFont];
+    attributes[NSForegroundColorAttributeName] = [_displaySettings codeColor];
     
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    [paragraphStyle setParagraphSpacing:kParagraphSpacingNone];
-    [paragraphStyle setFirstLineHeadIndent:kCodeIndentation];
-    [paragraphStyle setHeadIndent:kCodeIndentation];
-    [paragraphStyle setTailIndent:-kCodeIndentation];
+    [paragraphStyle setParagraphSpacing:[_displaySettings paragraphSpacingCode]];
+    [paragraphStyle setFirstLineHeadIndent:[_displaySettings codeIndentation]];
+    [paragraphStyle setHeadIndent:[_displaySettings codeIndentation]];
+    [paragraphStyle setTailIndent:-[_displaySettings codeIndentation]];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     [target addAttributes:attributes range:effectiveRange];
@@ -461,9 +296,16 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
                        inRange:(NSRange)effectiveRange
                       toTarget:(NSMutableAttributedString *)target
 {
-    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    [paragraphStyle setParagraphSpacing:kParagraphSpacingLarge];
-    [paragraphStyle setLineSpacing:1.1f];
+     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    [paragraphStyle setParagraphSpacing:[_displaySettings paragraphSpacing]];
+    [paragraphStyle setLineSpacing:[_displaySettings paragraphLineSpacing]];
+    [paragraphStyle setFirstLineHeadIndent:[_displaySettings paragraphFirstLineHeadIndent]];
+
+    if (!_renderedFirstParagraph) {
+        [paragraphStyle setFirstLineHeadIndent:[_displaySettings firstParagraphFirstLineHeadIndent]];
+        _renderedFirstParagraph = YES;
+    }
+    [paragraphStyle setHeadIndent:[_displaySettings paragraphHeadIndent]];
     
     NSDictionary *attributes = @{NSParagraphStyleAttributeName : paragraphStyle};
     [target addAttributes:attributes range:effectiveRange];
@@ -506,10 +348,10 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
     insertedCharacters += [self insertBulletIntoTarget:target color:bulletColor atIndex:effectiveRange.location];
     
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    [paragraphStyle setLineSpacing:kLineSpacingSmall];
+     [paragraphStyle setLineSpacing:[_displaySettings lineSpacingSmall]];
     
     NSDictionary *indentationAttributes = @{
-                                            NSFontAttributeName : [UIFont systemFontOfSize:kBulletIndentation],
+                                            NSFontAttributeName : [UIFont systemFontOfSize:[_displaySettings bulletIndentation]],
                                             NSParagraphStyleAttributeName : paragraphStyle
                                             };
     
@@ -533,7 +375,10 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    [paragraphStyle setParagraphSpacing:kParagraphSpacingSmall];
+    [paragraphStyle setParagraphSpacing:[_displaySettings paragraphSpacingHeading]];
+    [paragraphStyle setLineSpacing:[_displaySettings paragraphLineSpacingHeading]];
+    [paragraphStyle setFirstLineHeadIndent:[_displaySettings headerFirstLineHeadIndent]];
+    [paragraphStyle setHeadIndent:[_displaySettings headerHeadIndent]];
     
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
@@ -541,25 +386,26 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
     
     switch ([element[@"level"] integerValue]) {
         case 1:
-            attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self h1Font]];
+            attributes[NSFontAttributeName] = [_displaySettings h1Font];
             break;
         case 2:
-            attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self h2Font]];
+            [paragraphStyle setParagraphSpacing:[_displaySettings paragraphSpacingH2]];
+            attributes[NSFontAttributeName] = [_displaySettings h2Font];
             break;
         case 3:
-            attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self h3Font]];
+            attributes[NSFontAttributeName] = [_displaySettings h3Font];
             break;
         case 4:
-            attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self h4Font]];
+            attributes[NSFontAttributeName] = [_displaySettings h4Font];
             break;
         case 5:
-            attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self h5Font]];
+            attributes[NSFontAttributeName] = [_displaySettings h5Font];
             break;
         case 6:
-            attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self h6Font]];
+            attributes[NSFontAttributeName] = [_displaySettings h6Font];
             break;
         default:
-            attributes[NSFontAttributeName] = [self UIFontFromCTFont:[self defaultFont]];
+            attributes[NSFontAttributeName] = [_displaySettings defaultFont];
             break;
     }
     

--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -97,6 +97,8 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
         [self renderBoldItalicElement:element toTarget:target];
     } else if (elementType == BPText) {
         [self renderTextElement:element toTarget:target];
+    } else if (elementType == BPStrikethrough) {
+        [self renderStruckthroughElement:element toTarget:target];
     } else if (elementType == BPParagraph) {
         [self renderParagraphElement:element inRange:effectiveRange toTarget:target];
     } else if (elementType == BPHeader) {

--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -58,20 +58,6 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
     return self;
 }
 
-- (void)elementWalker:(BPElementWalker *)elementWalker
-     willVisitElement:(BPElement *)element
-        withTextRange:(NSRange)textRange
-{
-    // do nothing
-}
-
-- (int)elementWalker:(BPElementWalker *)elementWalker
-     didVisitElement:(BPElement *)element
-       withTextRange:(NSRange)textRange
-{
-    return [self convertElement:element toTarget:_attributedText range:textRange];
-}
-
 - (void)dealloc
 {
     if (_defaultFont != NULL)    CFRelease(_defaultFont);
@@ -91,6 +77,22 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 - (void)resetAttributedText
 {
     _attributedText = [[NSMutableAttributedString alloc] init];
+}
+
+#pragma mark BPElementVisitor
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+     willVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange
+{
+    // do nothing
+}
+
+- (int)elementWalker:(BPElementWalker *)elementWalker
+     didVisitElement:(BPElement *)element
+       withTextRange:(NSRange)textRange
+{
+    return [self convertElement:element toTarget:_attributedText range:textRange];
 }
 
 #pragma mark Fonts

--- a/Bypass/Bypass.h
+++ b/Bypass/Bypass.h
@@ -9,3 +9,8 @@
 #import <UIKit/UIKit.h>
 #import <Bypass/BPDisplaySettings.h>
 #import <Bypass/BPMarkdownView.h>
+#import <Bypass/BPElement.h>
+#import <Bypass/BPDocument.h>
+#import <Bypass/BPParser.h>
+#import <Bypass/BPAttributedTextVisitor.h>
+#import <Bypass/BPAttributedStringConverter.h>


### PR DESCRIPTION
Here's another one for you guys :-) 
I figured that this repo is going to be the new main repo for iOS and since it has already removed the boost dependency I switched to it today (since I want to build using Xcode 5).

This pull request basically re-adds some of the fixes/additions made in the last week, that didn't make it here because of the visitor pattern.
1. BPDisplaySettings are used/respected again
2. Fix for random crash in renderSpanElement:withFont:attributes:toTarget: (text == nil) is re-applied
3. Strikethrough works again
4. Added a wrapper object BPAttributedStringConverter that internally uses the new visitor pattern, but keeps the public API intact (and makes the parser easier to use from outside)

I haven't done extensive testing yet, but I didn't encounter any issues so far.

What do you think?
