### PR TITLE
Don't throw away link title information but keep it in a custom attribute

### DIFF
--- a/Bypass/BPAttributedTextVisitor.h
+++ b/Bypass/BPAttributedTextVisitor.h
@@ -26,6 +26,7 @@
 @class BPDisplaySettings;
 
 OBJC_EXPORT NSString* const BPLinkStyleAttributeName;
+OBJC_EXPORT NSString* const BPLinkTitleAttributeName;
 
 @interface BPAttributedTextVisitor : NSObject <BPElementVisitor>
 

--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -23,6 +23,7 @@
 #import "BPDisplaySettings.h"
 
 NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
+NSString *const BPLinkTitleAttributeName = @"BPLinkTitleAttributeName";
 
 
 @implementation BPAttributedTextVisitor {
@@ -239,6 +240,12 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     attributes[NSUnderlineStyleAttributeName] = @(NSUnderlineStyleSingle);
     attributes[NSForegroundColorAttributeName] = [_displaySettings linkColor];
     attributes[BPLinkStyleAttributeName] = element[@"link"];
+
+    NSString *linkTitle = element[@"title"];
+    if (linkTitle != nil) {
+        attributes[BPLinkTitleAttributeName] = linkTitle;
+    }
+
     [self renderSpanElement:element
                    withFont:[_displaySettings defaultFont]
                  attributes:attributes toTarget:target];


### PR DESCRIPTION
Might be useful for some to keep the title attribute around.
