### PR TITLE
Use display settings from BPMarkdownView so that user can cusomize it

### DIFF
--- a/Bypass/BPAttributedTextVisitor.h
+++ b/Bypass/BPAttributedTextVisitor.h
@@ -33,6 +33,7 @@ OBJC_EXPORT NSString* const BPLinkTitleAttributeName;
 @property (nonatomic, readonly) NSMutableAttributedString* attributedText;
 @property (nonatomic, strong) BPDisplaySettings *displaySettings;
 
+- (id)initWithDisplaySettings:(BPDisplaySettings *)displaySettings;
 - (void)resetAttributedText;
 
 @end

--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -48,7 +48,11 @@ NSString *const BPLinkTitleAttributeName = @"BPLinkTitleAttributeName";
     
     if (self != nil) {
         _attributedText = [[NSMutableAttributedString alloc] init];
-        _displaySettings = displaySettings;
+        if(displaySettings != nil) {
+            _displaySettings = displaySettings;
+        } else {
+            _displaySettings = [[BPDisplaySettings alloc] init];
+        }
     }
     
     return self;

--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -42,6 +42,18 @@ NSString *const BPLinkTitleAttributeName = @"BPLinkTitleAttributeName";
     return self;
 }
 
+- (id)initWithDisplaySettings:(BPDisplaySettings *)displaySettings
+{
+    self = [super init];
+    
+    if (self != nil) {
+        _attributedText = [[NSMutableAttributedString alloc] init];
+        _displaySettings = displaySettings;
+    }
+    
+    return self;
+}
+
 - (void)resetAttributedText
 {
     _attributedText = [[NSMutableAttributedString alloc] init];

--- a/Bypass/BPMarkdownView.m
+++ b/Bypass/BPMarkdownView.m
@@ -54,6 +54,7 @@ static const NSTimeInterval kReorientationDuration = 0.3;
  */
 static CFArrayRef
 BPCreatePageFrames(BPDocument *document,
+                   BPDisplaySettings *displaySettings,
                    CGSize pageSize,
                    CGSize *suggestedContentSizeOut,
                    NSAttributedString **attributedTextOut,
@@ -61,7 +62,7 @@ BPCreatePageFrames(BPDocument *document,
                    id accessibilityContainer) {
     BPElementWalker* walker = [[BPElementWalker alloc] init];
     
-    BPAttributedTextVisitor* textVisitor = [[BPAttributedTextVisitor alloc] init];
+    BPAttributedTextVisitor* textVisitor = [[BPAttributedTextVisitor alloc] initWithDisplaySettings:displaySettings];
     [walker addElementVisitor:textVisitor];
     
     BPAccessibilityVisitor* accessVisitor = [[BPAccessibilityVisitor alloc] initWithAccessibilityContainer:accessibilityContainer];
@@ -258,7 +259,7 @@ BPCreatePageFrames(BPDocument *document,
         NSArray* accessElements;
         CGSize contentSize;
         
-        CFArrayRef pageFrames = BPCreatePageFrames(_document, pageSize, &contentSize, &attributedText, &accessElements, self);
+        CFArrayRef pageFrames = BPCreatePageFrames(_document, _displaySettings, pageSize, &contentSize, &attributedText, &accessElements, self);
         
         _attributedText = attributedText;
         accessibleElements = accessElements;


### PR DESCRIPTION
Currently, BPMarkDownView has displaySettings property but is not used. This change will allow user to customize font and colors.
