### PR TITLE
Make sure every attributed string has a font set

### DIFF
--- a/Bypass/BPAttributedTextVisitor.m
+++ b/Bypass/BPAttributedTextVisitor.m
@@ -126,14 +126,22 @@ NSString *const BPLinkTitleAttributeName = @"BPLinkTitleAttributeName";
 - (int)insertNewlineIntoTarget:(NSMutableAttributedString*) target
                        atIndex:(int) index
 {
-    [target insertAttributedString:[[NSMutableAttributedString alloc] initWithString:@"\n"] atIndex:index];
+    [target insertAttributedString:
+        [[NSMutableAttributedString alloc] initWithString:@"\n"
+                                           attributes:@{
+                                                NSFontAttributeName: [_displaySettings defaultFont]
+                                            }] atIndex:index];
     
     return 1;
 }
 
 - (int)appendNewlineOntoTarget:(NSMutableAttributedString *)target
 {
-    [target appendAttributedString:[[NSMutableAttributedString alloc] initWithString:@"\n"]];
+    [target appendAttributedString:
+        [[NSMutableAttributedString alloc] initWithString:@"\n"
+                                            attributes:@{
+                                                NSFontAttributeName: [_displaySettings defaultFont]
+                                            }]];
     
     return 1;
 }


### PR DESCRIPTION
Every attribute set needs to have a font set, otherwise boundingRectWithSize:options:context: returns inaccurate results. It was only missing in a couple of places, where I have now added it. Tested, and works nicely.
